### PR TITLE
Fix 'outputRelativePath' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,14 +307,13 @@ module.exports = function (options) {
                 });
                 filePaths
                   .map(function (path) {
-                    return [path, getPath(path)]
+                    return getPath(path);
                   })
                   .forEach(function (filePath) {
-                    var relPath = filePath[0].replace(path.basename(filePath[0]), path.basename(filePath[1]));
                     if (type === 'js') {
-                      html.push('<script src="' + relPath + '"></script>');
+                      html.push('<script src="' + filePath + '"></script>');
                     } else {
-                      html.push('<link rel="stylesheet" href="' + relPath + '"/>');
+                      html.push('<link rel="stylesheet" href="' + filePath + '"/>');
                     }
                   });
               });


### PR DESCRIPTION
To properly serve transformed statics under different prefix (like
'/static/') than original filepath, path.basename() invocation should
be avoided, since it strips that prefix away - effectively nullifying
'outputRelativePath' option.