### PR TITLE
More detailed path in not found error

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ module.exports = function (options) {
         var excs = paths[i].exc.map(globSync);
         var filepaths = _.difference(_.union.apply(null, incs), _.union.apply(null, excs));
         if (filepaths[0] === undefined) {
-          throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i] + ' not found!');
+          throw new gutil.PluginError('gulp-usemin', 'Path ' + paths[i].src + ' not found!');
         }
         promises.push.apply(promises, filepaths.map(function (filepath) {
           var fileDeferred = when.defer();


### PR DESCRIPTION
When you have specified some asset with unresolved path, the plugin throws:
`Potentially unhandled rejection [1] Error: Path [object Object] not found!`

This PR changes that message, specifies url of unresolved asset. I.e:

`Potentially unhandled rejection [1] Error: Path ./node_modules/jquery/dist/jquery.js not found!`